### PR TITLE
chore: switch image and source repo links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.idea
+.idea/*.xml
+.idea/*.iml
+.idea/inspectionProfiles

--- a/.idea/runConfigurations/ct_lint.xml
+++ b/.idea/runConfigurations/ct_lint.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="ct-lint" type="RUN_ANYTHING_CONFIGURATION" factoryName="RunAnythingFactory">
+    <option name="arguments" value="lint --all --chart-dirs=charts" />
+    <option name="command" value="ct" />
+    <option name="inputText" value="" />
+    <option name="workingDirectory" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/helm_template.xml
+++ b/.idea/runConfigurations/helm_template.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="helm-template" type="RUN_ANYTHING_CONFIGURATION" factoryName="RunAnythingFactory">
+    <option name="arguments" value="template test charts/ark-cluster --values charts/ark-cluster/ci/clustertest-values.yaml" />
+    <option name="command" value="helm" />
+    <option name="inputText" value="" />
+    <option name="workingDirectory" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/charts/ark-cluster/README.md
+++ b/charts/ark-cluster/README.md
@@ -2,7 +2,7 @@
 ARK Survival Evolved is sandbox survival game available for example on Steam: https://store.steampowered.com/app/346110/ARK_Survival_Evolved/
 
 ## How It Works
-The chart is based on the docker image https://github.com/thmhoag/arkserver 
+The chart is based on the docker image https://github.com/SickHub/arkserver (previously https://github.com/drpsychick/arkserver forked from https://github.com/thmhoag/arkserver)
 which uses `arkmanager` (https://github.com/arkmanager/ark-server-tools) 
 to install and update ARK from steam as well as mods.
 
@@ -17,7 +17,8 @@ All servers will share the `ShooterGame` server files and `clusters` directory, 
   * one volume for the shared cluster files (mounted as `/arkserver/ShooterGame/Saved/clusters`)
 
 ## Deploy ark-cluster
-First start ONE server, he should also have all mods configured that you want to use.
+Only configure ONE server to do `updateOnStart`, all other servers will wait for the server and mods to be up to date 
+before starting the server. The server doing the updates should thus be the one with ALL mods configured you want to use.
 
 You **must** configure [`persistence`](#persistence), if you want your data to be persisted (Game, Saved, ... everything).
 
@@ -90,7 +91,8 @@ servers:
 ```
 
 ### Persistence
-Ways of configuring persistence. If you don't configure persistence, the game will be downloaded in `emptyDir` and all changes lost when the pod is deleted.
+Ways of configuring persistence. If you don't configure persistence, the game will be downloaded in `emptyDir` and all 
+changes lost when the pod is deleted.
 1. provide a `PersistentVolume` for game, cluster and each server
 2. provide an `existingClaim` for game, cluster and each server
 
@@ -129,8 +131,6 @@ persistence:
 ```
 
 ### Shared Server Files
-TODO: make this optional!
-
 Server files are shared across multiple ARK instances of the cluster
 ```yaml
 extraEnvVars:
@@ -151,7 +151,6 @@ metadata:
   name: arkcluster-quota
 spec:
   hard:
-    # limit to max 3 running servers
     requests.cpu: "3"
     requests.memory: 18Gi
     # limit to max 3 running servers
@@ -166,5 +165,5 @@ spec:
 ## Credits
 Inspired by
 * https://github.com/itzg/minecraft-server-charts
-* https://github.com/thmhoag/arkserver
+* https://github.com/SickHub/arkserver
 * Icon from [Freepik](https://www.freepik.com) found on [Flaticon](https://www.flaticon.com/)

--- a/charts/ark-cluster/templates/deployment.yaml
+++ b/charts/ark-cluster/templates/deployment.yaml
@@ -117,7 +117,6 @@ spec:
               value: "true"
             - name: am_arkopt_clusterid
               value: {{ $.Values.clusterName | quote }}
-            # TODO: make this optional
             - name: am_arkStagingDir
               value: ""
             - name: ARKSERVER_SHARED
@@ -151,7 +150,7 @@ spec:
               value: {{ $rconpass | quote }}
             {{- end }}
             - name: am_ark_GameModIds
-              value: {{ join "," $mods | quote }}
+              value: '{{ join "," $mods | quote }}'
             - name: am_arkGameIniFile
               value: /arkconfig/Game.ini
             - name: am_arkGameUserSettingsIniFile

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -4,9 +4,9 @@ entries:
   - annotations:
       artifacthub.io/links: |
         - name: Image source
-          url: https://github.com/DrPsychick/arkserver
+          url: https://github.com/SickHub/arkserver
         - name: Image DockerHub
-          url: https://hub.docker.com/r/drpsychick/arkcluster
+          url: https://hub.docker.com/r/drpsychick/arkserver
     apiVersion: v2
     appVersion: latest
     created: "2021-07-09T18:57:27.313886+02:00"
@@ -33,9 +33,9 @@ entries:
   - annotations:
       artifacthub.io/links: |
         - name: Image source
-          url: https://github.com/DrPsychick/arkserver
+          url: https://github.com/SickHub/arkserver
         - name: Image DockerHub
-          url: https://hub.docker.com/r/drpsychick/arkcluster
+          url: https://hub.docker.com/r/drpsychick/arkserver
     apiVersion: v2
     appVersion: latest
     created: "2021-07-09T18:57:27.31305+02:00"
@@ -62,9 +62,9 @@ entries:
   - annotations:
       artifacthub.io/links: |
         - name: Image source
-          url: https://github.com/DrPsychick/arkserver
+          url: https://github.com/SickHub/arkserver
         - name: Image DockerHub
-          url: https://hub.docker.com/r/drpsychick/arkcluster
+          url: https://hub.docker.com/r/drpsychick/arkserver
     apiVersion: v2
     appVersion: latest
     created: "2021-07-09T18:57:27.312232+02:00"
@@ -91,9 +91,9 @@ entries:
   - annotations:
       artifacthub.io/links: |
         - name: Image source
-          url: https://github.com/DrPsychick/arkserver
+          url: https://github.com/SickHub/arkserver
         - name: Image DockerHub
-          url: https://hub.docker.com/r/drpsychick/arkcluster
+          url: https://hub.docker.com/r/drpsychick/arkserver
     apiVersion: v2
     appVersion: latest
     created: "2021-07-09T18:57:27.31137+02:00"
@@ -120,9 +120,9 @@ entries:
   - annotations:
       artifacthub.io/links: |
         - name: Image source
-          url: https://github.com/thmhoag/arkserver
+          url: https://github.com/SickHub/arkserver
         - name: Image DockerHub
-          url: https://hub.docker.com/r/drpsychick/arkcluster
+          url: https://hub.docker.com/r/drpsychick/arkserver
     apiVersion: v2
     appVersion: latest
     created: "2021-07-09T18:57:27.310559+02:00"
@@ -143,9 +143,9 @@ entries:
   - annotations:
       artifacthub.io/links: |
         - name: Image source
-          url: https://github.com/thmhoag/arkserver
+          url: https://github.com/SickHub/arkserver
         - name: Image DockerHub
-          url: https://hub.docker.com/r/drpsychick/arkcluster
+          url: https://hub.docker.com/r/drpsychick/arkserver
     apiVersion: v2
     appVersion: latest
     created: "2021-07-09T18:57:27.309699+02:00"
@@ -166,9 +166,9 @@ entries:
   - annotations:
       artifacthub.io/links: |
         - name: Image source
-          url: https://github.com/thmhoag/arkserver
+          url: https://github.com/SickHub/arkserver
         - name: Image DockerHub
-          url: https://hub.docker.com/r/drpsychick/arkcluster
+          url: https://hub.docker.com/r/drpsychick/arkserver
     apiVersion: v2
     appVersion: latest
     created: "2021-07-09T18:57:27.308964+02:00"
@@ -189,9 +189,9 @@ entries:
   - annotations:
       artifacthub.io/links: |
         - name: Image source
-          url: https://github.com/thmhoag/arkserver
+          url: https://github.com/SickHub/arkserver
         - name: Image DockerHub
-          url: https://hub.docker.com/r/drpsychick/arkcluster
+          url: https://hub.docker.com/r/drpsychick/arkserver
     apiVersion: v2
     appVersion: latest
     created: "2021-07-09T18:57:27.308091+02:00"
@@ -212,9 +212,9 @@ entries:
   - annotations:
       artifacthub.io/links: |
         - name: Image source
-          url: https://github.com/thmhoag/arkserver
+          url: https://github.com/SickHub/arkserver
         - name: Image DockerHub
-          url: https://hub.docker.com/r/drpsychick/arkcluster
+          url: https://hub.docker.com/r/drpsychick/arkserver
     apiVersion: v2
     appVersion: latest
     created: "2021-07-09T18:57:27.306499+02:00"


### PR DESCRIPTION
* fix: use drpsychick/arkserver image (maintained, regularly built, different & recent versions)
* chore: use 'focal' by default
* feat: commit runConfigurations for helm & ct