### PR TITLE
fix: ensure AutUpdateOnStart is set, default to false

### DIFF
--- a/charts/ark-cluster/templates/deployment.yaml
+++ b/charts/ark-cluster/templates/deployment.yaml
@@ -121,10 +121,8 @@ spec:
               value: ""
             - name: ARKSERVER_SHARED
               value: {{ $.Values.persistence.game.mountPath | quote }}
-            {{- if .updateOnStart }}
             - name: am_arkAutoUpdateOnStart
-              value: "true"
-            {{- end }}
+              value: {{ default "false" .updateOnStart | quote }}
             - name: am_ark_SessionName
               value: {{ .sessionName | quote }}
             - name: am_serverMap


### PR DESCRIPTION
relates to #14 

Reason being that if you run multiple servers in a cluster with shared server files and mods, you only want ONE server to updateOnStart. All others should wait till server and mods are up to date.

Waiting for a `arkmanager` release to merge this and change the default because of a small issue that prevents this from working correctly: https://github.com/arkmanager/ark-server-tools/issues/1234

Meanwhile you can use `drpsychick/arkserver:latest-master` and `updateOnStart` for each server explicitly (a good idea anyway 😉)
