### PR TITLE
Remove volumeName if not using existing pv

### DIFF
--- a/charts/ark-cluster/templates/pvc.yaml
+++ b/charts/ark-cluster/templates/pvc.yaml
@@ -28,8 +28,6 @@ spec:
   {{- end }}
   {{- if .Values.persistence.game.existingVolume }}
   volumeName: {{ tpl .Values.persistence.game.existingVolume . }}
-  {{- else }}
-  volumeName: {{ template "ark-cluster.fullname" . }}-game
   {{- end }}
 {{- end }}
 {{- if and .Values.persistence.enabled (not .Values.persistence.cluster.existingClaim) }}
@@ -62,8 +60,6 @@ spec:
   {{- end }}
   {{- if .Values.persistence.game.existingVolume }}
   volumeName: {{ tpl .Values.persistence.cluster.existingVolume . }}
-  {{- else }}
-  volumeName: {{ template "ark-cluster.fullname" . }}-cluster
   {{- end }}
 {{- end }}
 
@@ -102,8 +98,6 @@ spec:
   {{- end }}
   {{- if $.Values.persistence.save.existingVolume }}
   volumeName: {{ printf "%s-%s" (tpl $.Values.persistence.save.existingVolume .) $name }}
-  {{- else }}
-  volumeName: {{ printf "%s-%s" $chart_name $name }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Removes the volumeMode from pvc if not using an existing pv.