### PR TITLE
fix: make volumeName optional

### DIFF
--- a/charts/ark-cluster/README.md
+++ b/charts/ark-cluster/README.md
@@ -11,7 +11,7 @@ All servers will share the `ShooterGame` server files and `clusters` directory, 
 
 ### Requirements for Kubernetes
 * ARK communicates its port to the client, thus the external port must be identical to the port where the ARK pod is listening.
-* Required persistent volumes:
+* Persistent volumes:
   * one volume for the shared server (game) files (the biggest volume) to save space (mounted as `/arkserver`)
   * one volume for each server (mounted as `/arkserver/ShooterGame/Saved`)
   * one volume for the shared cluster files (mounted as `/arkserver/ShooterGame/Saved/clusters`)

--- a/charts/ark-cluster/templates/pvc.yaml
+++ b/charts/ark-cluster/templates/pvc.yaml
@@ -28,7 +28,7 @@ spec:
   {{- end }}
   {{- if .Values.persistence.game.existingVolume }}
   volumeName: {{ tpl .Values.persistence.game.existingVolume . }}
-  {{- else }}
+  {{- else if .Values.persistence.existingVolumes }}
   volumeName: {{ template "ark-cluster.fullname" . }}-game
   {{- end }}
 {{- end }}
@@ -62,7 +62,7 @@ spec:
   {{- end }}
   {{- if .Values.persistence.game.existingVolume }}
   volumeName: {{ tpl .Values.persistence.cluster.existingVolume . }}
-  {{- else }}
+  {{- else if .Values.persistence.existingVolumes }}
   volumeName: {{ template "ark-cluster.fullname" . }}-cluster
   {{- end }}
 {{- end }}
@@ -102,7 +102,7 @@ spec:
   {{- end }}
   {{- if $.Values.persistence.save.existingVolume }}
   volumeName: {{ printf "%s-%s" (tpl $.Values.persistence.save.existingVolume .) $name }}
-  {{- else }}
+  {{- else if .Values.persistence.existingVolumes }}
   volumeName: {{ printf "%s-%s" $chart_name $name }}
   {{- end }}
 {{- end }}

--- a/charts/ark-cluster/values.yaml
+++ b/charts/ark-cluster/values.yaml
@@ -159,6 +159,10 @@ containerPorts:
 persistence:
   enabled: false
 
+  # use generic existing volume names prefixed with <cluster-name>: -game, -cluster, -<server-name>
+  #
+  existingVolumes: false
+
   # game files from steam, the largest volume, includes installed mods
   game:
     accessModes:
@@ -183,8 +187,7 @@ persistence:
   # contains the world save game and configuration files
   # keeping a backup of this is enough to get your server back up
   save:
-    # A named, existing Persistent Volume, if none given, the name
-    # will be generated: <cluster-name>-<server-name>
+    # A named, existing Persistent Volume
     #
     # existingVolume:
 


### PR DESCRIPTION
@DebakelOrakel : I found a way to keep the generic volume names, but make them optional. Please have a look if this would work for you as well.

closes #17 